### PR TITLE
Fix urllib3 import error when using urllib3>=2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-clearml==1.7.2
+clearml==1.10.4
 github3.py==3.2.0
 tabulate==0.9.0
 pandas==1.5.1


### PR DESCRIPTION
Error when running action


>`
ImportError: cannot import name 'appengine' from 'urllib3.contrib' (/opt/hostedtoolcache/Python/3.10.11/x64/lib/python3.10/site-packages/urllib3/contrib/__init__.py)
Error: Process completed with exit code 1.
`